### PR TITLE
Update parmashell_functions

### DIFF
--- a/src/ParmaShell/parmashell_functions
+++ b/src/ParmaShell/parmashell_functions
@@ -26,7 +26,7 @@ function pl { pp ; cd ParmanodL ; a ; }
 function d { cd $HOME/Desktop && a ; }
 function dl { cd $HOME/Downloads && a ; }
 function dp { cd $HOME/.parmanode && a ; }
-function h { cd & a ; }
+function h { cd && a ; }
 function b { cd $HOME/.bitcoin ; a ; }
 
 


### PR DESCRIPTION
This change added a needed ampersand to the "h" function so that the "h" function will now work correctly.