### PR TITLE
Fix command typo in check_rpc_global.sh

### DIFF
--- a/src/bitcoin/check_rpc_global.sh
+++ b/src/bitcoin/check_rpc_global.sh
@@ -63,8 +63,8 @@ fi
 
 #ElectrumX
 if [[ -e $hp/electrumx/electrumx.conf ]] ; then
-export electrumx_rpcuser="$(cat $hp/electrumx/electrumx.conf | grep DAEMON_URL | cut -d : -f 2 | cur -d / -f 3)"
-export electrumx_rpcpassword="$(cat $hp/electrumx/electrumx.conf | grep DAEMON_URL | cut -d : -f 3 | cur -d @ -f 1)"
+export electrumx_rpcuser="$(cat $hp/electrumx/electrumx.conf | grep DAEMON_URL | cut -d : -f 2 | cut -d / -f 3)"
+export electrumx_rpcpassword="$(cat $hp/electrumx/electrumx.conf | grep DAEMON_URL | cut -d : -f 3 | cut -d @ -f 1)"
 fi
 
 


### PR DESCRIPTION
Fixed command typo to "cut -d / -f 3)" from "cur -d / -f 3)"